### PR TITLE
docs: replace deprecated GitHub installer

### DIFF
--- a/BioLizardStyleR/vignettes/BioLizardStyleR.Rmd
+++ b/BioLizardStyleR/vignettes/BioLizardStyleR.Rmd
@@ -50,17 +50,17 @@ knitr::include_graphics(system.file("logo", "BiolizardLogo.png", package="BioLiz
 </code></pre>
 
 # 1. Installation
-To install the `BioLizardStyleR` package directly from GitHub, you will need to utilize the `devtools` package. The package requires our signature font "Red Hat Display". If the font is not yet installed, installation  will be attempted automatically when you load the library.
+To install the `BioLizardStyleR` package directly from GitHub, use the `pak` package. The package requires our signature font "Red Hat Display". If the font is not yet installed, installation will be attempted automatically when you load the library.
 
 ```
-if (!requireNamespace("devtools", quietly = TRUE)) {
-install.packages("devtools")
+if (!requireNamespace("pak", quietly = TRUE)) {
+install.packages("pak")
 }
 
 # make sure to look up BioConductor packages (used in the vignette)
 setRepositories(ind = c(1:6, 8))
 
-devtools::install_github("lizard-bio/nature-grade-visualization-playground", subdir="BioLizardStyleR")
+pak::pak("lizard-bio/nature-grade-visualization-playground/BioLizardStyleR")
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Development was continued by Anikó Meijer and Artuur Couckuyt.
 ### Installing BioLizardStyleR
 
 ```{r}
-if (!requireNamespace("devtools", quietly = TRUE)) {
-  install.packages("devtools")
+if (!requireNamespace("pak", quietly = TRUE)) {
+  install.packages("pak")
 }
 
-devtools::install_github("lizard-bio/nature-grade-visualization-playground", subdir="BioLizardStyleR")
+pak::pak("lizard-bio/nature-grade-visualization-playground/BioLizardStyleR")
 
 ```
 


### PR DESCRIPTION
Closes #61

Updates the README and BioLizardStyleR vignette to install the package with `pak::pak()` instead of deprecated `devtools::install_github()`. The package subdirectory remains explicit in the GitHub package reference.

Validation:
- Confirmed pak supports GitHub subdirectory references.
- Confirmed no `install_github` references remain in the installation docs.
- Ran `git diff --check`.

## BioLizardStyleR

- [ ] unit testing: run `devtools::test()` from root dir of the package (not applicable; documentation only)
- [x] adjust documentation
- [ ] describe changes in NEWS.md (not required for documentation correction)
- [ ] bump up version number (not required)
- [ ] Run `devtools::check(args = c("--no-examples"))` before pushing (R is unavailable in this environment)